### PR TITLE
Small fix to run migrations queries without a transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.phar
 /composer.lock
 .phpunit.result.cache
+/phpunit.xml

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -25,7 +25,7 @@ class UpdateCommand extends Command
     {
         $this->setName('dbal:schema:update')
             ->addOption('force', 'f', InputOption::VALUE_NONE)
-            ->addOption('no-transactions', 'n', InputOption::VALUE_NONE);
+            ->addOption('no-transactions', 't', InputOption::VALUE_NONE);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -24,12 +24,17 @@ class UpdateCommand extends Command
     protected function configure(): void
     {
         $this->setName('dbal:schema:update')
-            ->addOption('force', 'f', InputOption::VALUE_NONE);
+            ->addOption('force', 'f', InputOption::VALUE_NONE)
+            ->addOption('no-transactions', 'n', InputOption::VALUE_NONE);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->schemaCommand->update($input->getOption('force'), $output);
+        $this->schemaCommand->update(
+            $input->getOption('force'),
+            $output,
+            $input->getOption('no-transactions'),
+        );
 
         return 0;
     }

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -25,7 +25,7 @@ class UpdateCommand extends Command
     {
         $this->setName('dbal:schema:update')
             ->addOption('force', 'f', InputOption::VALUE_NONE)
-            ->addOption('no-transactions', 't', InputOption::VALUE_NONE);
+            ->addOption('use-transaction', 't', InputOption::VALUE_NONE);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -33,7 +33,7 @@ class UpdateCommand extends Command
         $this->schemaCommand->update(
             $input->getOption('force'),
             $output,
-            $input->getOption('no-transactions'),
+            $input->getOption('use-transaction'),
         );
 
         return 0;

--- a/src/DbalSchemaCommand.php
+++ b/src/DbalSchemaCommand.php
@@ -23,7 +23,7 @@ class DbalSchemaCommand
     /**
      * Update the database schema to match the schema definition.
      */
-    public function update(bool $force, OutputInterface $output, bool $noTransaction = false): void
+    public function update(bool $force, OutputInterface $output, bool $withTransaction = false): void
     {
         $newSchema = new Schema();
         $this->schemaDefinition->define($newSchema);
@@ -43,7 +43,7 @@ class DbalSchemaCommand
             }
         };
 
-        if (false === $noTransaction) {
+        if (true === $withTransaction) {
             $this->db->transactional($migrationsRun);
         } else {
             $migrationsRun();


### PR DESCRIPTION
Add an option --no-transactions / -n to disable transaction to run migrations queries to fix https://github.com/mnapoli/dbal-schema/issues/11